### PR TITLE
feat: allow for custom factory on pair creation

### DIFF
--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -36,19 +36,26 @@ export const computePairAddress = ({
 }
 export class Pair {
   public readonly liquidityToken: Token
+  private readonly factoryAddress: string
   private readonly tokenAmounts: [CurrencyAmount<Token>, CurrencyAmount<Token>]
 
   public static getAddress(tokenA: Token, tokenB: Token): string {
     return computePairAddress({ factoryAddress: FACTORY_ADDRESS, tokenA, tokenB })
   }
 
-  public constructor(currencyAmountA: CurrencyAmount<Token>, tokenAmountB: CurrencyAmount<Token>) {
+  public getPairAddress(tokenA: Token, tokenB: Token): string {
+    return computePairAddress({ factoryAddress: this.factoryAddress, tokenA, tokenB })
+  }
+
+  public constructor(currencyAmountA: CurrencyAmount<Token>, tokenAmountB: CurrencyAmount<Token>, factoryAddress?: string) {
+    this.factoryAddress = factoryAddress ?? FACTORY_ADDRESS
+
     const tokenAmounts = currencyAmountA.currency.sortsBefore(tokenAmountB.currency) // does safety checks
       ? [currencyAmountA, tokenAmountB]
       : [tokenAmountB, currencyAmountA]
     this.liquidityToken = new Token(
       tokenAmounts[0].currency.chainId,
-      Pair.getAddress(tokenAmounts[0].currency, tokenAmounts[1].currency),
+      this.getPairAddress(tokenAmounts[0].currency, tokenAmounts[1].currency),
       18,
       'NIIFI-V1',
       'NiiFi V1'
@@ -134,7 +141,7 @@ export class Pair {
     if (JSBI.equal(outputAmount.quotient, ZERO)) {
       throw new InsufficientInputAmountError()
     }
-    return [outputAmount, new Pair(inputReserve.add(inputAmount), outputReserve.subtract(outputAmount))]
+    return [outputAmount, new Pair(inputReserve.add(inputAmount), outputReserve.subtract(outputAmount), this.factoryAddress)]
   }
 
   public getInputAmount(outputAmount: CurrencyAmount<Token>): [CurrencyAmount<Token>, Pair] {
@@ -155,7 +162,7 @@ export class Pair {
       outputAmount.currency.equals(this.token0) ? this.token1 : this.token0,
       JSBI.add(JSBI.divide(numerator, denominator), ONE)
     )
-    return [inputAmount, new Pair(inputReserve.add(inputAmount), outputReserve.subtract(outputAmount))]
+    return [inputAmount, new Pair(inputReserve.add(inputAmount), outputReserve.subtract(outputAmount), this.factoryAddress)]
   }
 
   public getLiquidityMinted(

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -47,7 +47,11 @@ export class Pair {
     return computePairAddress({ factoryAddress: this.factoryAddress, tokenA, tokenB })
   }
 
-  public constructor(currencyAmountA: CurrencyAmount<Token>, tokenAmountB: CurrencyAmount<Token>, factoryAddress?: string) {
+  public constructor(
+    currencyAmountA: CurrencyAmount<Token>,
+    tokenAmountB: CurrencyAmount<Token>,
+    factoryAddress?: string
+  ) {
     this.factoryAddress = factoryAddress ?? FACTORY_ADDRESS
 
     const tokenAmounts = currencyAmountA.currency.sortsBefore(tokenAmountB.currency) // does safety checks
@@ -141,7 +145,10 @@ export class Pair {
     if (JSBI.equal(outputAmount.quotient, ZERO)) {
       throw new InsufficientInputAmountError()
     }
-    return [outputAmount, new Pair(inputReserve.add(inputAmount), outputReserve.subtract(outputAmount), this.factoryAddress)]
+    return [
+      outputAmount,
+      new Pair(inputReserve.add(inputAmount), outputReserve.subtract(outputAmount), this.factoryAddress)
+    ]
   }
 
   public getInputAmount(outputAmount: CurrencyAmount<Token>): [CurrencyAmount<Token>, Pair] {
@@ -162,7 +169,10 @@ export class Pair {
       outputAmount.currency.equals(this.token0) ? this.token1 : this.token0,
       JSBI.add(JSBI.divide(numerator, denominator), ONE)
     )
-    return [inputAmount, new Pair(inputReserve.add(inputAmount), outputReserve.subtract(outputAmount), this.factoryAddress)]
+    return [
+      inputAmount,
+      new Pair(inputReserve.add(inputAmount), outputReserve.subtract(outputAmount), this.factoryAddress)
+    ]
   }
 
   public getLiquidityMinted(

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,7 +1,7 @@
-export {};
+export {}
 
 declare global {
   interface Window {
-    __RUNTIME_CONFIG__: any; // 👈️ turn off type checking
+    __RUNTIME_CONFIG__: any // 👈️ turn off type checking
   }
 }


### PR DESCRIPTION
**Purpose**
Adds optional flexibility to the `Pair` class to allow for the factory contract to be specified - useful for additional network deployments/test environments.

Static function `getAddress()` has been left as-is to maintain compatibility, with a new function `getPairAddress()` now available to call the internal `factoryAddress` set.

**Issues**
No issues linked.

**Changes**
- Add optional param `factoryAddress` to `Pair` constructor. Fallbacks to original functionality of `FACTORY_ADDRESS` constant if omitted.
- Add `getPairAddress()` function.